### PR TITLE
feat: support weight decimals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.7
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.6.0
+	github.com/shopspring/decimal v1.4.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/spf13/viper v1.18.2
 	golang.org/x/crypto v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/internal/db/edit.go
+++ b/internal/db/edit.go
@@ -44,7 +44,7 @@ func Create(path string) {
 func InsertEx(path string, ex models.Exercise) {
 
 	sqlStatement := `INSERT INTO exercises (GR, PLACE, NAME, DESCR, IMAGE, COLOR, WEIGHT, REPS) 
-	VALUES ('%s','%s','%s','%s','%s','%s','%d','%d');`
+	VALUES ('%s','%s','%s','%s','%s','%s','%v','%d');`
 
 	ex.Group = quoteStr(ex.Group)
 	ex.Name = quoteStr(ex.Name)
@@ -59,7 +59,7 @@ func InsertEx(path string, ex models.Exercise) {
 func InsertSet(path string, ex models.Set) {
 
 	sqlStatement := `INSERT INTO sets (DATE, NAME, COLOR, WEIGHT, REPS) 
-	VALUES ('%s','%s','%s','%d','%d');`
+	VALUES ('%s','%s','%s','%v','%d');`
 
 	ex.Name = quoteStr(ex.Name)
 
@@ -72,7 +72,7 @@ func InsertSet(path string, ex models.Set) {
 func InsertW(path string, ex models.BodyWeight) {
 
 	sqlStatement := `INSERT INTO weight (DATE, WEIGHT) 
-	VALUES ('%s','%d');`
+	VALUES ('%s','%v');`
 
 	sqlStatement = fmt.Sprintf(sqlStatement, ex.Date, ex.Weight)
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"github.com/shopspring/decimal"
+
 	"github.com/aceberg/ExerciseDiary/internal/auth"
 )
 
@@ -22,25 +24,25 @@ type Conf struct {
 
 // Exercise - one exercise
 type Exercise struct {
-	ID     int    `db:"ID"`
-	Group  string `db:"GR"`
-	Place  string `db:"PLACE"`
-	Name   string `db:"NAME"`
-	Descr  string `db:"DESCR"`
-	Image  string `db:"IMAGE"`
-	Color  string `db:"COLOR"`
-	Weight int    `db:"WEIGHT"`
-	Reps   int    `db:"REPS"`
+	ID     int             `db:"ID"`
+	Group  string          `db:"GR"`
+	Place  string          `db:"PLACE"`
+	Name   string          `db:"NAME"`
+	Descr  string          `db:"DESCR"`
+	Image  string          `db:"IMAGE"`
+	Color  string          `db:"COLOR"`
+	Weight decimal.Decimal `db:"WEIGHT"`
+	Reps   int             `db:"REPS"`
 }
 
 // Set - one set
 type Set struct {
-	ID     int    `db:"ID"`
-	Date   string `db:"DATE"`
-	Name   string `db:"NAME"`
-	Color  string `db:"COLOR"`
-	Weight int    `db:"WEIGHT"`
-	Reps   int    `db:"REPS"`
+	ID     int             `db:"ID"`
+	Date   string          `db:"DATE"`
+	Name   string          `db:"NAME"`
+	Color  string          `db:"COLOR"`
+	Weight decimal.Decimal `db:"WEIGHT"`
+	Reps   int             `db:"REPS"`
 }
 
 // AllExData - all sets and exercises
@@ -60,9 +62,9 @@ type HeatMapData struct {
 
 // BodyWeight - store weight
 type BodyWeight struct {
-	ID     int    `db:"ID"`
-	Date   string `db:"DATE"`
-	Weight int    `db:"WEIGHT"`
+	ID     int             `db:"ID"`
+	Date   string          `db:"DATE"`
+	Weight decimal.Decimal `db:"WEIGHT"`
 }
 
 // GuiData - web gui data

--- a/internal/web/exercise.go
+++ b/internal/web/exercise.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 
 	"github.com/aceberg/ExerciseDiary/internal/db"
 	"github.com/aceberg/ExerciseDiary/internal/models"
@@ -53,7 +54,7 @@ func saveExerciseHandler(c *gin.Context) {
 	reps := c.PostForm("reps")
 
 	oneEx.ID, _ = strconv.Atoi(id)
-	oneEx.Weight, _ = strconv.Atoi(weight)
+	oneEx.Weight, _ = decimal.NewFromString(weight)
 	oneEx.Reps, _ = strconv.Atoi(reps)
 
 	// log.Println("ONEEX =", oneEx)

--- a/internal/web/public/js/index.js
+++ b/internal/web/public/js/index.js
@@ -9,9 +9,9 @@ function addExercise(name, weight, reps) {
     <td>
         <input name="name" type="text" class="form-control" value="${name}">
     </td><td>
-        <input name="weight" type="number" class="form-control" value="${weight}">
+        <input name="weight" type="number" step="any" min="0" class="form-control" value="${weight}">
     </td><td>
-        <input name="reps" type="number" class="form-control" value="${reps}">
+        <input name="reps" type="number" min="0" class="form-control" value="${reps}">
     </td><td>
         <button class="btn del-set-button" type="button" title="Delete" onclick="delExercise(${id})">
             <i class="bi bi-x-square"></i>

--- a/internal/web/set.go
+++ b/internal/web/set.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 
 	"github.com/aceberg/ExerciseDiary/internal/db"
 	"github.com/aceberg/ExerciseDiary/internal/models"
@@ -15,7 +16,8 @@ func setHandler(c *gin.Context) {
 
 	var formData []models.Set
 	var oneSet models.Set
-	var weight, reps int
+	var reps int
+	var weight decimal.Decimal
 
 	_ = c.PostFormMap("sets")
 
@@ -29,7 +31,7 @@ func setHandler(c *gin.Context) {
 	for i := 0; i < len; i++ {
 		oneSet.Date = date
 		oneSet.Name = formMap["name"][i]
-		weight, _ = strconv.Atoi(formMap["weight"][i])
+		weight, _ = decimal.NewFromString(formMap["weight"][i])
 		reps, _ = strconv.Atoi(formMap["reps"][i])
 		oneSet.Weight = weight
 		oneSet.Reps = reps

--- a/internal/web/templates/exercise.html
+++ b/internal/web/templates/exercise.html
@@ -32,11 +32,11 @@
                 </tr>
                 <tr>
                     <td>Weight (default)</td>
-                    <td><input name="weight" type="number" class="form-control" value="{{ .OneEx.Weight }}"></td>
+                    <td><input name="weight" type="number" step="any" min="0" class="form-control" value="{{ .OneEx.Weight }}"></td>
                 </tr>
                 <tr>
                     <td>Reps (default)</td>
-                    <td><input name="reps" type="number" class="form-control" value="{{ .OneEx.Reps }}"></td>
+                    <td><input name="reps" type="number" min="0" class="form-control" value="{{ .OneEx.Reps }}"></td>
                 </tr>
                 <tr>
                     <td><button type="submit" class="btn btn-primary">Save</button></td>

--- a/internal/web/templates/index.html
+++ b/internal/web/templates/index.html
@@ -24,7 +24,7 @@
             </tr>
             <tr>
               <td>Weight</td>
-              <td><input name="weight" type="number" class="form-control"></td>
+              <td><input name="weight" type="number" step="any" min="0" class="form-control"></td>
             </tr>
             <tr>
               <td>

--- a/internal/web/templates/weight.html
+++ b/internal/web/templates/weight.html
@@ -40,7 +40,7 @@
                 <div class="card-body">
                     <form action="/weight/" method="post" name="sets" class="input-group">
                         <input name="date" type="date" class="form-control" id="todayDate">
-                        <input name="weight" type="number" class="form-control">
+                        <input name="weight" type="number" step="any" min="0" class="form-control">
                         <button type="submit" class="btn btn-primary">Add</button>
                     </form>
                 </div>

--- a/internal/web/weight.go
+++ b/internal/web/weight.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/shopspring/decimal"
 
 	"github.com/aceberg/ExerciseDiary/internal/db"
 	"github.com/aceberg/ExerciseDiary/internal/models"
@@ -18,7 +19,7 @@ func addWeightHandler(c *gin.Context) {
 	w.Date = c.PostForm("date")
 	weightStr := c.PostForm("weight")
 
-	w.Weight, _ = strconv.Atoi(weightStr)
+	w.Weight, _ = decimal.NewFromString(weightStr)
 
 	db.InsertW(appConfig.DBPath, w)
 


### PR DESCRIPTION
Use the `shopspring/decimal` library to add support for decimal weight values.

 - Change each `Weight` field's type to `decimal.Decimal`
 - Replace `strconv.Atio()` with `decimal.NewFromString()` for Weight
 - Modify SQL statements to insert the decimal value
 - Update weight inputs to allow decimal places and a min value of zero

This approach works without modifying the column type due to SQLite's type affinity. Ideally the column type would be changed to a more suitable type to better support other DBs, like PostgreSQL, in the future. However, that would require decisions to be made around migration processes, which may be better deferred until that work is undertaken.

Resolves aceberg/ExerciseDiary#4